### PR TITLE
changed_fact_table_to_incremental_models

### DIFF
--- a/transform/warehouse/models/staging/calls.sql
+++ b/transform/warehouse/models/staging/calls.sql
@@ -1,3 +1,11 @@
+{{
+    config(
+        materialized = "incremental",
+        unique_key = "cad_number",
+        incremental_strategy = "merge"
+    )
+}}
+
 with calls_clean as (
 select 
 cad_number,
@@ -43,6 +51,10 @@ case when sensitive_call = TRUE then 1
 end as is_sensitive_call,
 data_updated_at  as call_data_updated_at
 from {{source('dispatch','calls')}}
+{% if is_incremental() %}
+    where data_updated_at >= (select max(call_data_updated_at) from {{this}})
+{% endif %}
+
 
 )
 


### PR DESCRIPTION
<!-- 
    Please read the url below 
    if you have any confusions 
    for how to fill these fields 
    https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
-->
## What?
<!-- Please only fill the space below and leave a space before the line starts -->

![image](https://github.com/user-attachments/assets/ea3a2229-f930-4a56-8b15-398c37681e3e)

---
## Why?
<!-- Please only fill the space below and leave a space before the line starts -->
changed from full refresh to incremental models ,no need to refresh entire model

---
## How?
<!-- Please only fill the space below and leave a space before the line starts -->
added the following code at the start of the model:
{{
    config(
        materialized = "incremental",
        unique_key = "cad_number",
        incremental_strategy = "merge"
    )
}}

added the following code after the from clause
{% if is_incremental() %}
    where data_updated_at >= (select max(call_data_updated_at) from {{this}})
{% endif %}



---
## Testing?
<!-- Please only fill the space below and leave a space before the line starts -->

---
## Screenshots (optional)
<!-- Please only fill the space below and leave a space before the line starts -->

---
## Anything Else?
<!-- Please only fill the space below and leave a space before the line starts -->
